### PR TITLE
Fix Netlify configuration

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@
 # for the website are in the /website folder.
 [build]
 base    = "website"
-publish = "public"
+publish = "website/public"
 command = "make build"
 
 [build.environment]


### PR DESCRIPTION
In PR #100 I changed the base folder for the website assets and it turns out that the `publish` directory for Netlify is absolute and not relative to the specified `base` directory. This has temporarily broken the website build (no big deal); this PR should fix it.