### PR TITLE
Add GitHub repository link to website

### DIFF
--- a/website/config.yaml
+++ b/website/config.yaml
@@ -6,8 +6,8 @@ disableKinds: [taxonomy, taxonomyTerm]
 params:
   description: |
     An effort to create an open standard for transmitting metrics at scale, with support for both [text representation](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format) and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
-    <br /><br />
-    **Coming soon**
+  subdescription: |
+    OpenMetrics is **coming soon**. You can track the project's progress in the [OpenObservability/OpenMetrics](https://github.com/OpenObservability/OpenMetrics) repository on GitHub.
   font:
     face: Noto Sans
     sizes: [300, 400, 600, 700]

--- a/website/layouts/partials/hero.html
+++ b/website/layouts/partials/hero.html
@@ -1,12 +1,19 @@
-{{- $description := .Site.Params.description | markdownify }}
+{{- $description := .Site.Params.description }}
+{{- $subdescription := .Site.Params.subdescription }}
 <section class="hero is-fullheight has-text-centered">
   <div class="hero-body hero--main">
     <div class="container">
       <img class="is-main-logo title is-spaced" src="{{ "/images/logo/openmetrics.png" | relURL }}" alt="OpenMetrics logo">
 
       <h2 class="subtitle is-size-3 is-size-4-touch">
-        {{ $description }}
+        {{ $description | markdownify }}
       </h2>
+
+      <br />
+
+      <h4 class="subtitle is-size-5 is-size-6-touch">
+        {{ $subdescription | markdownify }}
+      </h4>
     </div>
   </div>
 </section>


### PR DESCRIPTION
This PR directs people who come to the website to check out this repo for more information.

@RichiH This might be premature. If you don't want people directed the repo just yet, we can wait to merge this.