### PR TITLE
Use OpenMetrics icon as favicon

### DIFF
--- a/website/config.yaml
+++ b/website/config.yaml
@@ -8,3 +8,4 @@ params:
     An effort to create an open standard for transmitting metrics at scale, with support for both [text representation](https://prometheus.io/docs/instrumenting/exposition_formats/#text-based-format) and [Protocol Buffers](https://developers.google.com/protocol-buffers/).
   subdescription: |
     OpenMetrics is **coming soon**. You can track the project's progress in the [OpenMetrics](https://github.com/OpenObservability/OpenMetrics) repository on GitHub or on the [OpenMetrics mailing list](https://groups.google.com/forum/m/#!forum/openmetrics).
+  favicon: /images/logo/logo.png

--- a/website/layouts/partials/css.html
+++ b/website/layouts/partials/css.html
@@ -13,4 +13,5 @@
 {{- $prodCss := $css | minify | fingerprint }}
 <link rel="stylesheet" href="{{ $prodCss.RelPermalink }}" integrity="{{ $prodCss.Data.Integrity }}">
 {{- end }}
-<link rel="shortcut icon" href="{{ "/favicon.png" | relURL }}">
+{{- $favicon := .Site.Params.favicon }}
+<link rel="shortcut icon" href="{{ $favicon | relURL }}">


### PR DESCRIPTION
Replaces the current placeholder favicon (the CNCF logo) with the OpenMetrics logo