### PR TITLE
Protobuf updates, use protobuf.Timestamp for timestamps, cleanup comments and add explicit advice

### DIFF
--- a/proto/Makefile
+++ b/proto/Makefile
@@ -1,0 +1,7 @@
+# NB(rob): Move this to top level Makefile once merged to master, 
+# then can add a rule to CircleCI to build the protobuf to make sure
+# it is valid.
+%.pb.go: %.proto
+	protoc --go_out=. $<
+
+all: $(patsubst %.proto,%.pb.go,$(wildcard *.proto))

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -1,17 +1,16 @@
 syntax = "proto3";
 
+// The OpenMetrics protobuf schema which defines the protobuf
+// wire format. 
+// Ensure to intepret "required" as semantically required for a valid message.
+// All string fields MUST be UTF-8 encoded strings.
 package openmetrics;
 
-// This is a description of the OpenMetrics data model in a proto
-// form. Additionally, it serves as the proto wire format.
-//
-// Interpret "required" as semantically required. Some fields are
-// semantically required depending on the values of the other fields
-// (and indicated by comments).
+import "google/protobuf/timestamp.proto";
 
-// The top-level message sent on the wire.
+// The top-level container type that is encoded and sent over the wire.
 message MetricSet {
-  // Each MetricPoints has one or more points from a single metric.
+  // Each MetricPoints has one or more points for a single metric.
   repeated MetricPoints metric_points = 1;
 }
 
@@ -44,32 +43,43 @@ message MetricDescriptor {
   // underscores are reserved for monitoring-system internal use.
   string name = 1;
 
+  // Required.
+  MetricType MetricType = 2;
+
   // STATE_SETs and INFO types must not have a unit.
   // Must match the regexp [a-zA-Z_:][a-zA-Z0-9_:]*
-  string unit = 2;
+  string unit = 3;
 
-  // Required.
-  Type type = 3;
-
+  // Optional description of the metric name.
   string description = 4;
 
-  enum Type {
-    UNKNOWN = 0;  // double or int valued point
-    GAUGE = 1;    // double or int valued point
-    COUNTER = 2;  // double or int valued point.
-    STATE_SET = 3;
-    INFO = 4;  // provides information about the entity being monitored
-    CUMULATIVE_HISTOGRAM = 5;
-    GAUGE_HISTOGRAM = 6;
-    // Summary quantiles are not recommended, since they cannot be
-    // aggregated.
-    SUMMARY = 7;
-  }
   // Note: No bucketing is defined for a HISTOGRAM in the descriptor.
   // It is an implementation detail of the backend whether it can handle
   // changes in bucketing for a metric. Same for SUMMARY (quantiles are
   // not defined here), and STATE_SET (the set of possible values is
   // defined in each point).
+}
+
+// The type of a metric.
+enum MetricType {
+  // Unknown must use double or int valued points.
+  UNKNOWN = 0;
+  // Gauge must use double or int valued points.
+  GAUGE = 1;
+  // Counter must use double or int valued points.
+  COUNTER = 2;
+  // State set must use state set value points.
+  STATE_SET = 3;
+  // Info provides information about the target being monitored
+  // and must use info value points.
+  INFO = 4;
+  // Cumulative histogram must use histogram value points.
+  CUMULATIVE_HISTOGRAM = 5;
+  // Gauge histogram must use histogram value points.
+  GAUGE_HISTOGRAM = 6;
+  // Summary quantiles are not recommended, since they cannot be
+  // aggregated.
+  SUMMARY = 7;
 }
 
 // A name-value pair. These are used in multiple places: identifying
@@ -82,15 +92,9 @@ message Label {
   string value = 2;
 }
 
-message Timestamp {
-  // Required.
-  int64 seconds = 1;  // Seconds since the epoch. Negative values are permitted
-
-  uint32 nanoseconds = 2;
-}
-
 // A point in a timeseries.
 message Point {
+  // Required.
   oneof value {
     double double_value = 1;
     int64 int_value = 2;
@@ -103,15 +107,16 @@ message Point {
   // Not required, but SHOULD be specified for COUNTER, SUMMARY or
   // CUMULATIVE_HISTOGRAM type.
   //
-  // The cumulative value is over
-  // the time interval (start_timestamp, timestamp].
+  // The cumulative value is over the time interval 
+  // (start_timestamp, timestamp].
   // If start_timestamp is present and timestamp is absent,
   // the backend assigned timestamp may be used to construct the time
   // interval.
-  Timestamp start_timestamp = 7;
+  google.protobuf.Timestamp start_timestamp = 7;
 
+  // Not required.
   // If not specified, the timestamp will be decided by the backend.
-  Timestamp timestamp = 8;
+  google.protobuf.Timestamp timestamp = 8;
 }
 
 // Value for CUMULATIVE_HISTOGRAM or GAUGE_HISTOGRAM point.
@@ -130,7 +135,7 @@ message HistogramValue {
   // exponential sequence, or each bucket can be specified explicitly.
   // `BucketOptions` does not include the number of values in each bucket.
   //
-  // A bucket has a 0 lower bound and an inclusive upper bound for the
+  // A bucket has an exclusive lower bound and an inclusive upper bound for the
   // values that are counted for that bucket. That is, buckets are
   // cumulative. The upper bound of successive buckets must be increasing.
   // There is an implicit overflow bucket that extends up to +infinity.
@@ -153,7 +158,7 @@ message HistogramValue {
     //
     // There are `num_explicit_buckets` (N) buckets plus the overflow
     // bucket. Bucket `i` (0 <= i < N) has upper bound : offset + (width * i).
-    // Note that when offset = 0, bucket 0 represents the interval [0, 0].
+    // Note that when offset = 0, bucket 0 represents the interval (0, 0].
     message Linear {
       // Required.
       // Must be greater than 0.
@@ -175,7 +180,7 @@ message HistogramValue {
     //
     // There are `num_exponential_buckets` + 1 (N) buckets plus the overflow
     // bucket.
-    // Bucket 0 represents the interval [0, 0].
+    // Bucket 0 represents the interval (0, 0].
     // Bucket `i` (1 <= i < N) has upper bound :
     //   scale * (growth_factor ^ (i - 1)).
     message Exponential {
@@ -192,7 +197,7 @@ message HistogramValue {
       double scale = 3;
     }
 
-    // Specifies a set of buckets with arbitrary upper-bounds
+    // Specifies a set of buckets with arbitrary upper-bounds.
     //
     // There are `size(bounds)` (N) explicit buckets plus the overflow bucket.
     // Bucket `i` (0 <= i < N) has upper bound: bounds[i].
@@ -213,20 +218,23 @@ message HistogramValue {
   // The order of the values in `bucket_counts` follows the bucket numbering
   // schemes described for the three bucket types.
   repeated BucketCount bucket_counts = 4;
+
   message BucketCount {
     // Required.
     // Count is the number of values for a bucket of the histogram.
     uint64 count = 1;
 
+    // Not required.
     // An example of a value that fell into this bucket.
     Exemplar exemplar = 2;
+
     message Exemplar {
       // Required.
       // The value of the example.
       double value = 1;
 
       // The timestamp of the example. Optional but SHOULD set it.
-      Timestamp timestamp = 2;
+      google.protobuf.Timestamp timestamp = 2;
 
       // Additional information about the example value // (e.g. trace id).
       // The sum of lengths of all the strings in all the labels must not
@@ -255,24 +263,24 @@ message InfoValue {
   repeated Label info = 1;
 }
 
-// Value for SUMMARY point.
+// Value for SUMMARY point. The start_timestamp only applies to the sum 
+// and count. The quantiles can be reset at arbitrary unknown times.
 message SummaryValue {
-  // Sum and count are not required but SHOULD be specified.
-  // These are not required since some systems (e.g. DropWizard) do not
-  // expose them.
-  //
-  // The start_timestamp only applies to the sum and count.
-  // The quantiles can be reset at arbitrary unknown times.
-
+  // Not required, but SHOULD be specified. This is for compatibility 
+  // since some common systems do not expose them.
   double sum = 1;
+
+  // Not required, but SHOULD be specified. This is for compatibility 
+  // since some common systems do not expose them.
   uint64 count = 2;
 
-  // Not required, but SHOULD be specified.
   repeated Quantile quantile = 3;
+
   message Quantile {
-    // Required.
-    // Must be in the interval [0.0, 1.0].
+    // Required. Must be in the interval [0.0, 1.0].
     double quantile = 1;
+
+    // Required.
     double value = 2;
   }
 }

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -51,6 +51,7 @@ message MetricDescriptor {
 
   // STATE_SETs and INFO types must not have a unit.
   // Must match the regexp [a-zA-Z_:][a-zA-Z0-9_:]*
+  // If unit set, if MUST be a suffix on the metric name too (e.g. "foo_seconds").
   string unit = 3;
 
   // Optional description of the metric name.
@@ -248,7 +249,7 @@ message HistogramValue {
 
 // Value for STATE_SET point.
 message StateSetValue {
-  // Required, at least one.
+  // Optional, should set at least one.
   // Each state must have a unique name. Any number of states may be enabled.
   repeated State states = 1;
 

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -51,7 +51,9 @@ message MetricDescriptor {
 
   // STATE_SETs and INFO types must not have a unit.
   // Must match the regexp [a-zA-Z_:][a-zA-Z0-9_:]*
-  // If unit set, if MUST be a suffix on the metric name too (e.g. "foo_seconds").
+  // If unit set, if MUST be a suffix on the metric name too. If the 
+  // original name of the metric was "foo" and the unit was seconds 
+  // then the name must be specified as "foo_seconds".
   string unit = 3;
 
   // Optional description of the metric name.

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -30,6 +30,7 @@ message Timeseries {
   // Labels applying to all points.
   repeated Label label = 1;
 
+  // Optional.
   // If there is more than one point, all must have a timestamp field
   // and they must be in increasing order of timestamp.
   // If there is only one point and has no timestamp field, the receiver

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -20,7 +20,7 @@ message MetricPoints {
   // Required.
   MetricDescriptor metric_descriptor = 1;
 
-  // Required, at least one.
+  // Optional.
   repeated Timeseries timeseries = 2;
 }
 
@@ -68,19 +68,17 @@ enum MetricType {
   UNKNOWN = 0;
   // Gauge must use double point values.
   GAUGE = 1;
-  // Counter must use double point values.
+  // Counter must use double point values or int values.
   COUNTER = 2;
   // State set must use state set value points.
   STATE_SET = 3;
-  // Info provides information about the target being monitored
-  // and must use info value points.
+  // Info must use info value points.
   INFO = 4;
   // Cumulative histogram must use histogram value points.
   CUMULATIVE_HISTOGRAM = 5;
   // Gauge histogram must use histogram value points.
   GAUGE_HISTOGRAM = 6;
-  // Summary quantiles are not recommended, since they cannot be
-  // aggregated, they must use summary value points.
+  // Summary quantiles must use summary value points.
   SUMMARY = 7;
 }
 
@@ -99,10 +97,11 @@ message Point {
   // Required.
   oneof value {
     double double_value = 1;
-    HistogramValue histogram_value = 2;
-    StateSetValue state_set_value = 3;
-    InfoValue info_value = 4;
-    SummaryValue summary_value = 5;
+    int64 int_value = 2;
+    HistogramValue histogram_value = 3;
+    StateSetValue state_set_value = 4;
+    InfoValue info_value = 5;
+    SummaryValue summary_value = 6;
   }
 
   // Not required, but SHOULD be specified for COUNTER, SUMMARY or
@@ -201,11 +200,11 @@ message HistogramValue {
     // Specifies a set of buckets with arbitrary upper-bounds.
     //
     // There are `size(bounds)` (N) explicit buckets plus the overflow bucket.
-    // Bucket `i` (0 <= i < N) has upper bound: bounds[i].
+    // Bucket `i` has upper bound: bounds[i].
     // The `bounds` field must contain at least one element.
     message Explicit {
-      // Required, at least one.
-      // The values must be monotonically increasing and >= 0.
+      // Optional, but SHOULD set it.
+      // The values must be monotonically increasing.
       repeated double bounds = 1;
     }
   }
@@ -231,15 +230,15 @@ message HistogramValue {
 
     message Exemplar {
       // Required.
-      // The value of the example.
+      // The value of the exemplar.
       double value = 1;
 
       // Optional, but SHOULD set it.
-      // The timestamp of the example.
+      // The timestamp of the exemplar.
       google.protobuf.Timestamp timestamp = 2;
 
       // Optional.
-      // Additional information about the example value (e.g. trace id).
+      // Additional information about the exemplar value (e.g. trace id).
       // The sum of lengths of all the strings in all the labels must not
       // exceed 64 UTF-8 characters.
       repeated Label label = 3;
@@ -264,7 +263,7 @@ message StateSetValue {
 
 // Value for INFO point.
 message InfoValue {
-  // Required, at least one.
+  // Optional, but SHOULD set it.
   repeated Label info = 1;
 }
 

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -136,7 +136,7 @@ message HistogramValue {
   // exponential sequence, or each bucket can be specified explicitly.
   // `BucketOptions` does not include the number of values in each bucket.
   //
-  // A bucket has an exclusive lower bound and an inclusive upper bound for the
+  // A bucket has no lower bound and an inclusive upper bound for the
   // values that are counted for that bucket. That is, buckets are
   // cumulative. The upper bound of successive buckets must be increasing.
   // There is an implicit overflow bucket that extends up to +infinity.

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -62,11 +62,11 @@ message MetricDescriptor {
 
 // The type of a metric.
 enum MetricType {
-  // Unknown must use double or int valued points.
+  // Unknown must use double point values.
   UNKNOWN = 0;
-  // Gauge must use double or int valued points.
+  // Gauge must use double point values.
   GAUGE = 1;
-  // Counter must use double or int valued points.
+  // Counter must use double point values.
   COUNTER = 2;
   // State set must use state set value points.
   STATE_SET = 3;
@@ -78,7 +78,7 @@ enum MetricType {
   // Gauge histogram must use histogram value points.
   GAUGE_HISTOGRAM = 6;
   // Summary quantiles are not recommended, since they cannot be
-  // aggregated.
+  // aggregated, they must use summary value points.
   SUMMARY = 7;
 }
 
@@ -97,11 +97,10 @@ message Point {
   // Required.
   oneof value {
     double double_value = 1;
-    int64 int_value = 2;
-    HistogramValue histogram_value = 3;
-    StateSetValue state_set_value = 4;
-    InfoValue info_value = 5;
-    SummaryValue summary_value = 6;
+    HistogramValue histogram_value = 2;
+    StateSetValue state_set_value = 3;
+    InfoValue info_value = 4;
+    SummaryValue summary_value = 5;
   }
 
   // Not required, but SHOULD be specified for COUNTER, SUMMARY or
@@ -121,10 +120,10 @@ message Point {
 
 // Value for CUMULATIVE_HISTOGRAM or GAUGE_HISTOGRAM point.
 message HistogramValue {
-  // Not required, but SHOULD be specified.
+  // Optional, but SHOULD be specified.
   double sum = 1;
 
-  // Not required, but SHOULD be specified.
+  // Optional, but SHOULD be specified.
   uint64 count = 2;
 
   // Required.
@@ -181,7 +180,7 @@ message HistogramValue {
     // There are `num_exponential_buckets` + 1 (N) buckets plus the overflow
     // bucket.
     // Bucket 0 represents the interval (0, 0].
-    // Bucket `i` (1 <= i < N) has upper bound :
+    // Bucket `i` (1 <= i < N) has upper bound:
     //   scale * (growth_factor ^ (i - 1)).
     message Exponential {
       // Required.
@@ -203,10 +202,10 @@ message HistogramValue {
     // Bucket `i` (0 <= i < N) has upper bound: bounds[i].
     // The `bounds` field must contain at least one element.
     message Explicit {
+      // Required, at least one.
       // The values must be monotonically increasing and >= 0.
       repeated double bounds = 1;
     }
-
   }
 
   // The number of values in each bucket of the histogram, as described in
@@ -224,7 +223,7 @@ message HistogramValue {
     // Count is the number of values for a bucket of the histogram.
     uint64 count = 1;
 
-    // Not required.
+    // Optional.
     // An example of a value that fell into this bucket.
     Exemplar exemplar = 2;
 
@@ -233,10 +232,12 @@ message HistogramValue {
       // The value of the example.
       double value = 1;
 
-      // The timestamp of the example. Optional but SHOULD set it.
+      // Optional, but SHOULD set it.
+      // The timestamp of the example.
       google.protobuf.Timestamp timestamp = 2;
 
-      // Additional information about the example value // (e.g. trace id).
+      // Optional.
+      // Additional information about the example value (e.g. trace id).
       // The sum of lengths of all the strings in all the labels must not
       // exceed 64 UTF-8 characters.
       repeated Label label = 3;
@@ -246,6 +247,7 @@ message HistogramValue {
 
 // Value for STATE_SET point.
 message StateSetValue {
+  // Required, at least one.
   // Each state must have a unique name. Any number of states may be enabled.
   repeated State states = 1;
 
@@ -260,20 +262,22 @@ message StateSetValue {
 
 // Value for INFO point.
 message InfoValue {
+  // Required, at least one.
   repeated Label info = 1;
 }
 
 // Value for SUMMARY point. The start_timestamp only applies to the sum 
 // and count. The quantiles can be reset at arbitrary unknown times.
 message SummaryValue {
-  // Not required, but SHOULD be specified. This is for compatibility 
-  // since some common systems do not expose them.
+  // Optional, but SHOULD be specified. 
+  // This is for compatibility since some common systems do not expose them.
   double sum = 1;
 
-  // Not required, but SHOULD be specified. This is for compatibility 
-  // since some common systems do not expose them.
+  // Optional, but SHOULD be specified. 
+  // This is for compatibility since some common systems do not expose them.
   uint64 count = 2;
 
+  // Required, at least one.
   repeated Quantile quantile = 3;
 
   message Quantile {

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -52,7 +52,7 @@ message MetricDescriptor {
   // STATE_SETs and INFO types must not have a unit.
   // Must match the regexp [a-zA-Z_:][a-zA-Z0-9_:]*
   // If unit set, if MUST be a suffix on the metric name too. If the 
-  // original name of the metric was "foo" and the unit was seconds 
+  // original name of the metric was "foo" and the unit was "seconds" 
   // then the name must be specified as "foo_seconds".
   string unit = 3;
 

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -136,7 +136,7 @@ message HistogramValue {
   // exponential sequence, or each bucket can be specified explicitly.
   // `BucketOptions` does not include the number of values in each bucket.
   //
-  // A bucket has a 0 lower bound and an inclusive upper bound for the
+  // A bucket has an exclusive lower bound and an inclusive upper bound for the
   // values that are counted for that bucket. That is, buckets are
   // cumulative. The upper bound of successive buckets must be increasing.
   // There is an implicit overflow bucket that extends up to +infinity.

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -169,7 +169,6 @@ message HistogramValue {
       double width = 2;
 
       // Required.
-      // Must be >= 0.
       double offset = 3;
     }
 
@@ -180,7 +179,7 @@ message HistogramValue {
     //
     // There are `num_exponential_buckets` + 1 (N) buckets plus the overflow
     // bucket.
-    // Bucket 0 represents the interval (0, 0].
+    // Bucket 0 represents the interval [0, 0].
     // Bucket `i` (1 <= i < N) has upper bound:
     //   scale * (growth_factor ^ (i - 1)).
     message Exponential {

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -135,7 +135,7 @@ message HistogramValue {
   // exponential sequence, or each bucket can be specified explicitly.
   // `BucketOptions` does not include the number of values in each bucket.
   //
-  // A bucket has an exclusive lower bound and an inclusive upper bound for the
+  // A bucket has a 0 lower bound and an inclusive upper bound for the
   // values that are counted for that bucket. That is, buckets are
   // cumulative. The upper bound of successive buckets must be increasing.
   // There is an implicit overflow bucket that extends up to +infinity.
@@ -158,7 +158,7 @@ message HistogramValue {
     //
     // There are `num_explicit_buckets` (N) buckets plus the overflow
     // bucket. Bucket `i` (0 <= i < N) has upper bound : offset + (width * i).
-    // Note that when offset = 0, bucket 0 represents the interval (0, 0].
+    // Note that when offset = 0, bucket 0 represents the interval [0, 0].
     message Linear {
       // Required.
       // Must be greater than 0.

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 // The OpenMetrics protobuf schema which defines the protobuf
 // wire format. 
-// Ensure to intepret "required" as semantically required for a valid message.
+// Ensure to interpret "required" as semantically required for a valid message.
 // All string fields MUST be UTF-8 encoded strings.
 package openmetrics;
 

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -20,11 +20,13 @@ message MetricPoints {
   // Required.
   MetricDescriptor metric_descriptor = 1;
 
+  // Required, at least one.
   repeated Timeseries timeseries = 2;
 }
 
 // A single timeseries.
 message Timeseries {
+  // Optional.
   // Labels applying to all points.
   repeated Label label = 1;
 

--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -278,7 +278,7 @@ message SummaryValue {
   // This is for compatibility since some common systems do not expose them.
   uint64 count = 2;
 
-  // Required, at least one.
+  // Optional.
   repeated Quantile quantile = 3;
 
   message Quantile {


### PR DESCRIPTION
These are updates based on the feedback provided by Bogdan and others and more closely matches the latest Protobuf format section of the draft RFC.