### PR TITLE
Update CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,24 @@
-version: 2
+---
+version: 2.1
+
+executors:
+  golang:
+    docker:
+      - image: cimg/go:1.15
+
 jobs:
   build:
-    docker:
-      - image: circleci/golang
+    executor: golang
     steps:
       - checkout
       - run: "make binaries"
   test-success:
-    docker:
-      - image: circleci/golang
+    executor: golang
     steps:
       - checkout
       - run: "make test-impl cmd-parser-text=echo"
   test-fail:
-    docker:
-      - image: circleci/golang
+    executor: golang
     steps:
       - checkout
       - run: "! make test-impl cmd-parser-text=false"


### PR DESCRIPTION
* Use new cimg/go for building.
* Use executor templating for build image.

Signed-off-by: Ben Kochie <superq@gmail.com>