### PR TITLE
proto/openmetrics_data_model.proto: Don't assign field number twice

### DIFF
--- a/proto/openmetrics_data_model.proto
+++ b/proto/openmetrics_data_model.proto
@@ -195,14 +195,14 @@ message SummaryValue {
   }
 
   // Optional. 
-  uint64 count = 2;
+  uint64 count = 3;
 
   // The time sum and count values began being collected for this summary.
   // Optional.
-  google.protobuf.Timestamp created = 3;
+  google.protobuf.Timestamp created = 4;
 
   // Optional.
-  repeated Quantile quantile = 4;
+  repeated Quantile quantile = 5;
 
   message Quantile {
     // Required. 


### PR DESCRIPTION
Compiling `proto/openmetrics_data_model.proto` with `libprotoc` `v3.6.1` fails
with:

> `protoc failed: open_metrics.proto:198: 18: Field number 2 has already been
  used in \"openmetrics.SummaryValue\" by field \"int_value\".\n"`

In the `SummaryValue` `message` the field number `2` is used twice, once for
`int_value` and once for `count`. With this commit, all field numbers within
`SummaryValue` are monotonically increasing instead.

As far as I can tell this never compiled in the first place, thus backward
compatibility should not be an issue.