### PR TITLE
List '_created' under GaugeHistogram suffixes

### DIFF
--- a/specification/OpenMetrics.md
+++ b/specification/OpenMetrics.md
@@ -158,7 +158,7 @@ Exposers SHOULD avoid names that could be confused with the suffixes that text f
 * Counter: '_total', '_created'
 * Summary: '_count', '_sum', '_created', '' (empty)
 * Histogram: '_count', '_sum', '_bucket', '_created'
-* GaugeHistogram: '_gcount', '_gsum', '_bucket', '_created'
+* GaugeHistogram: '_gcount', '_gsum', '_bucket'
 * Info: '_info'
 * Gauge: '' (empty)
 * StateSet: '' (empty)
@@ -202,7 +202,7 @@ A gauge MAY be used to encode an enum where the enum has many states and changes
 
 Counters measure discrete events. Common examples are the number of HTTP requests received, CPU seconds spent, or bytes sent. For counters how quickly they are increasing over time is what is of interest to a user.
 
-A MetricPoint in a Metric with the type Counter MUST have one value called Total. A Total is a non-NaN and MUST be monotonically non-decreasing over time, starting from 0. 
+A MetricPoint in a Metric with the type Counter MUST have one value called Total. A Total is a non-NaN and MUST be monotonically non-decreasing over time, starting from 0.
 
 A MetricPoint in a Metric with the type Counter SHOULD have a Timestamp value called Created. This can help ingestors discern between new metrics and long-running ones it did not see before.
 
@@ -520,7 +520,7 @@ The value of a UNIT or HELP line MAY be empty. This MUST be treated as if no met
 
 There MUST NOT be more than one of each type of metadata line for a MetricFamily. The ordering SHOULD be TYPE, UNIT, HELP.
 
-Aside from this metadata and the EOF line at the end of the message, you MUST NOT expose lines beginning with a #. 
+Aside from this metadata and the EOF line at the end of the message, you MUST NOT expose lines beginning with a #.
 
 #### Metric
 
@@ -650,7 +650,7 @@ foo_total 17.0 1520879607.789
 An example with a Metric with no labels, and a MetricPoint with no timestamp and a created:
 ~~~~
 # TYPE foo counter
-foo_total 17.0 
+foo_total 17.0
 foo_created 1520430000.123
 ~~~~
 
@@ -732,7 +732,7 @@ Quantiles MAY be in any order.
 #### Histogram
 
 The MetricPoint's Bucket Values Sample MetricNames MUST have the suffix "_bucket". If present, the MetricPoint's Sum Value Sample MetricName MUST have the suffix "_sum". If present, the MetricPoint's Created Value Sample MetricName MUST have the suffix "_created".
-If and only if a Sum Value is present in a MetricPoint, then the MetricPoint's +Inf Bucket value MUST also appear in a Sample with a MetricName with the suffix "_count". 
+If and only if a Sum Value is present in a MetricPoint, then the MetricPoint's +Inf Bucket value MUST also appear in a Sample with a MetricName with the suffix "_count".
 
 Buckets MUST be sorted in number increasing order of "le", and the value of the "le" label MUST follow the rules for Canonical Numbers.
 
@@ -775,10 +775,10 @@ foo_created  1520430000.123
 
 #### GaugeHistogram
 
-The MetricPoint's Bucket Values Sample MetricNames MUST have the suffix "_bucket". If present, the MetricPoint's Sum Value Sample MetricName MUST have the suffix "_gsum". If present, the MetricPoint's Created Value Sample MetricName MUST have the suffix "_created".
-If and only if a Sum Value is present in a MetricPoint, then the MetricPoint's +Inf Bucket value MUST also appear in a Sample with a MetricName with the suffix "_gcount". 
+The MetricPoint's Bucket Values Sample MetricNames MUST have the suffix "_bucket". If present, the MetricPoint's Sum Value Sample MetricName MUST have the suffix "_gsum".
+If and only if a Sum Value is present in a MetricPoint, then the MetricPoint's +Inf Bucket value MUST also appear in a Sample with a MetricName with the suffix "_gcount".
 
-Buckets MUST be sorted in number increasing order of "le", and the value of the "le" label MUST follow the rules for Canonical Numbers. 
+Buckets MUST be sorted in number increasing order of "le", and the value of the "le" label MUST follow the rules for Canonical Numbers.
 
 An example of a Metric with no labels, and one MetricPoint value with no Exemplar with no Exemplars in the buckets:
 ~~~~
@@ -790,7 +790,6 @@ foo_bucket{le="10"} 34.0
 foo_bucket{le="+Inf"} 42.0
 foo_gcount 42.0
 foo_gsum 3289.3
-foo_created  1520430000.123
 ~~~~
 
 #### Unknown
@@ -1025,7 +1024,7 @@ message SummaryValue {
     int64 int_value = 2;
   }
 
-  // Optional. 
+  // Optional.
   uint64 count = 3;
 
   // The time sum and count values began being collected for this summary.
@@ -1036,7 +1035,7 @@ message SummaryValue {
   repeated Quantile quantile = 5;
 
   message Quantile {
-    // Required. 
+    // Required.
     double quantile = 1;
 
     // Required.

--- a/specification/OpenMetrics.md
+++ b/specification/OpenMetrics.md
@@ -158,7 +158,7 @@ Exposers SHOULD avoid names that could be confused with the suffixes that text f
 * Counter: '_total', '_created'
 * Summary: '_count', '_sum', '_created', '' (empty)
 * Histogram: '_count', '_sum', '_bucket', '_created'
-* GaugeHistogram: '_gcount', '_gsum', '_bucket'
+* GaugeHistogram: '_gcount', '_gsum', '_bucket', '_created'
 * Info: '_info'
 * Gauge: '' (empty)
 * StateSet: '' (empty)

--- a/specification/OpenMetrics.txt
+++ b/specification/OpenMetrics.txt
@@ -5,12 +5,12 @@
 Ops WG                                                  R. Hartmann, Ed.
 Internet-Draft                                              Grafana Labs
 Intended status: Standards Track                               B. Kochie
-Expires: January 2, 2022                                          GitLab
+Expires: March 26, 2022                                           GitLab
                                                                B. Brazil
                                                        Robust Perception
                                                           R. Skillington
                                                             Chronosphere
-                                                           July 01, 2021
+                                                      September 22, 2021
 
 
      OpenMetrics, a cloud-native, highly scalable metrics protocol
@@ -20,8 +20,9 @@ Abstract
 
    OpenMetrics specifies today's de-facto standard for transmitting
    cloud-native metrics at scale, with support for both text
-   representation and Protocol Buffers and brings it into IETF.  It
-   supports both pull and push-based data collection.
+   representation and Protocol Buffers and brings it into an Internet
+   Engineering Task Force (IETF) standard.  It supports both pull and
+   push-based data collection.
 
 Status of This Memo
 
@@ -38,7 +39,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 2, 2022.
+   This Internet-Draft will expire on March 26, 2022.
 
 Copyright Notice
 
@@ -49,15 +50,15 @@ Copyright Notice
    Provisions Relating to IETF Documents
    (https://trustee.ietf.org/license-info) in effect on the date of
    publication of this document.  Please review these documents
-   carefully, as they describe your rights and restrictions with respect
 
 
 
-Hartmann, et al.         Expires January 2, 2022                [Page 1]
+Hartmann, et al.         Expires March 26, 2022                 [Page 1]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
+   carefully, as they describe your rights and restrictions with respect
    to this document.  Code Components extracted from this document must
    include Simplified BSD License text as described in Section 4.e of
    the Trust Legal Provisions and are provided without warranty as
@@ -105,15 +106,15 @@ Table of Contents
      5.2.  Extensions and Improvements . . . . . . . . . . . . . . .  29
      5.3.  Units and Base Units  . . . . . . . . . . . . . . . . . .  29
      5.4.  Statelessness . . . . . . . . . . . . . . . . . . . . . .  31
-     5.5.  Exposition Across Time and Metric Evolution . . . . . . .  31
 
 
 
-Hartmann, et al.         Expires January 2, 2022                [Page 2]
+Hartmann, et al.         Expires March 26, 2022                 [Page 2]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
+     5.5.  Exposition Across Time and Metric Evolution . . . . . . .  31
      5.6.  NaN . . . . . . . . . . . . . . . . . . . . . . . . . . .  32
      5.7.  Missing Data  . . . . . . . . . . . . . . . . . . . . . .  32
      5.8.  Exposition Performance  . . . . . . . . . . . . . . . . .  33
@@ -164,10 +165,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-
-Hartmann, et al.         Expires January 2, 2022                [Page 3]
+Hartmann, et al.         Expires March 26, 2022                 [Page 3]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 1.1.  Requirements Language
@@ -221,9 +221,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022                [Page 4]
+Hartmann, et al.         Expires March 26, 2022                 [Page 4]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    precedence.  This reduces repetition as the text wire format MUST be
@@ -277,9 +277,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022                [Page 5]
+Hartmann, et al.         Expires March 26, 2022                 [Page 5]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 3.1.7.  Exemplars
@@ -333,9 +333,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022                [Page 6]
+Hartmann, et al.         Expires March 26, 2022                 [Page 6]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 3.1.9.1.1.  Suffixes
@@ -357,7 +357,7 @@ Internet-Draft                 OpenMetrics                     July 2021
 
    o  Histogram: '_count', '_sum', '_bucket', '_created'
 
-   o  GaugeHistogram: '_gcount', '_gsum', '_bucket'
+   o  GaugeHistogram: '_gcount', '_gsum', '_bucket', '_created'
 
    o  Info: '_info'
 
@@ -389,9 +389,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022                [Page 7]
+Hartmann, et al.         Expires March 26, 2022                 [Page 7]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 3.1.9.5.  MetricSet
@@ -445,9 +445,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022                [Page 8]
+Hartmann, et al.         Expires March 26, 2022                 [Page 8]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    A MetricPoint in a Metric with the type Counter SHOULD have a
@@ -501,9 +501,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022                [Page 9]
+Hartmann, et al.         Expires March 26, 2022                 [Page 9]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 3.2.5.  Histogram
@@ -557,9 +557,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 10]
+Hartmann, et al.         Expires March 26, 2022                [Page 10]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 3.2.6.  GaugeHistogram
@@ -613,9 +613,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 11]
+Hartmann, et al.         Expires March 26, 2022                [Page 11]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    did not see before.  Created MUST NOT relate to the collection period
@@ -669,9 +669,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 12]
+Hartmann, et al.         Expires March 26, 2022                [Page 12]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    Push-based negotiation is inherently more complex, as the exposer
@@ -725,9 +725,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 13]
+Hartmann, et al.         Expires March 26, 2022                [Page 13]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
  realnumber =/ [SIGN] *DIGIT "." 1*DIGIT [ "e" [SIGN] 1*DIGIT ]
@@ -781,9 +781,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 14]
+Hartmann, et al.         Expires March 26, 2022                [Page 14]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    The content type MUST be: application/openmetrics-text;
@@ -837,9 +837,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 15]
+Hartmann, et al.         Expires March 26, 2022                [Page 15]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    Arbitrary integer and floating point rendering of numbers MUST NOT be
@@ -893,13 +893,13 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 16]
+Hartmann, et al.         Expires March 26, 2022                [Page 16]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
-   Grisu3 such as Grisu3 is not readily available, exposers MAY use a
-   different rendering.
+   Grisu3 is not readily available, exposers MAY use a different
+   rendering.
 
    A warning to implementers in C and other languages that share its
    printf implementation: The standard precision of %f, %e and %g is
@@ -949,9 +949,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 17]
+Hartmann, et al.         Expires March 26, 2022                [Page 17]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    # TYPE foo_seconds counter
@@ -1005,9 +1005,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 18]
+Hartmann, et al.         Expires March 26, 2022                [Page 18]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    # TYPE foo_seconds summary
@@ -1061,9 +1061,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 19]
+Hartmann, et al.         Expires March 26, 2022                [Page 19]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    An example with a Metric with no labels and MetricPoint with a
@@ -1117,9 +1117,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 20]
+Hartmann, et al.         Expires March 26, 2022                [Page 20]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    An example of an "entity" label on the Metric: ~~~~ # TYPE foo
@@ -1173,9 +1173,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 21]
+Hartmann, et al.         Expires March 26, 2022                [Page 21]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 4.1.5.6.  Histogram
@@ -1229,9 +1229,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 22]
+Hartmann, et al.         Expires March 26, 2022                [Page 22]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    Buckets MUST be sorted in number increasing order of "le", and the
@@ -1285,9 +1285,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 23]
+Hartmann, et al.         Expires March 26, 2022                [Page 23]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 4.2.2.  Protobuf schema
@@ -1341,9 +1341,9 @@ enum MetricType {
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 24]
+Hartmann, et al.         Expires March 26, 2022                [Page 24]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
   // Info must use info MetricPoint values.
@@ -1397,9 +1397,9 @@ message UnknownValue {
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 25]
+Hartmann, et al.         Expires March 26, 2022                [Page 25]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
   // Required.
@@ -1453,9 +1453,9 @@ message HistogramValue {
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 26]
+Hartmann, et al.         Expires March 26, 2022                [Page 26]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
   repeated Bucket buckets = 5;
@@ -1509,9 +1509,9 @@ message InfoValue {
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 27]
+Hartmann, et al.         Expires March 26, 2022                [Page 27]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 // Value for SUMMARY MetricPoint.
@@ -1565,9 +1565,9 @@ message SummaryValue {
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 28]
+Hartmann, et al.         Expires March 26, 2022                [Page 28]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 5.1.1.  Out of scope
@@ -1621,9 +1621,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 29]
+Hartmann, et al.         Expires March 26, 2022                [Page 29]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    joules, grams, meters, ratios, volts, amperes, and celsius.  Units
@@ -1677,9 +1677,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 30]
+Hartmann, et al.         Expires March 26, 2022                [Page 30]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    Going to that extreme would not be useful.  The possibility of having
@@ -1733,9 +1733,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 31]
+Hartmann, et al.         Expires March 26, 2022                [Page 31]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    A notable exception is that adding a label to the value of an Info
@@ -1789,9 +1789,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 32]
+Hartmann, et al.         Expires March 26, 2022                [Page 32]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 5.8.  Exposition Performance
@@ -1845,9 +1845,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 33]
+Hartmann, et al.         Expires March 26, 2022                [Page 33]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    DNS.  Rather the aim is to keep to a lightweight informal approach,
@@ -1901,9 +1901,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 34]
+Hartmann, et al.         Expires March 26, 2022                [Page 34]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    Within the Prometheus ecosystem a set of per-process metrics has
@@ -1957,9 +1957,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 35]
+Hartmann, et al.         Expires March 26, 2022                [Page 35]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 5.12.  Metric Names versus Labels
@@ -2013,9 +2013,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 36]
+Hartmann, et al.         Expires March 26, 2022                [Page 36]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    wire format.  In particular, the query languages created or adopted
@@ -2069,9 +2069,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 37]
+Hartmann, et al.         Expires March 26, 2022                [Page 37]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    own target metadata, it is still often useful to have access to the
@@ -2125,9 +2125,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 38]
+Hartmann, et al.         Expires March 26, 2022                [Page 38]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    As an example, you should not expose a gauge with the average rate of
@@ -2181,9 +2181,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 39]
+Hartmann, et al.         Expires March 26, 2022                [Page 39]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    While there are limited use cases for attaching timestamps to exposed
@@ -2237,9 +2237,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 40]
+Hartmann, et al.         Expires March 26, 2022                [Page 40]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    example ~~~~ # TYPE my_boot_time_seconds gauge # HELP
@@ -2281,8 +2281,8 @@ Internet-Draft                 OpenMetrics                     July 2021
    acceptable values.  In such a system, exposing bounds could be
    counter-productive.
 
-   For example a the maximum size of a queue may be exposed alongside
-   the number of items currently in the queue like: ~~~~ # HELP
+   For example the maximum size of a queue may be exposed alongside the
+   number of items currently in the queue like: ~~~~ # HELP
    acme_notifications_queue_capacity The capacity of the notifications
    queue.  # TYPE acme_notifications_queue_capacity gauge
    acme_notifications_queue_capacity 10000 # HELP
@@ -2293,9 +2293,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 41]
+Hartmann, et al.         Expires March 26, 2022                [Page 41]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
 5.18.  Size Limits
@@ -2349,9 +2349,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 42]
+Hartmann, et al.         Expires March 26, 2022                [Page 42]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    order of magnitude of the time series. 1,000 gauges with one Metric
@@ -2405,9 +2405,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 43]
+Hartmann, et al.         Expires March 26, 2022                [Page 43]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    If more than one metric endpoint needs to be reachable at a common IP
@@ -2461,9 +2461,9 @@ Internet-Draft                 OpenMetrics                     July 2021
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 44]
+Hartmann, et al.         Expires March 26, 2022                [Page 44]
 
-Internet-Draft                 OpenMetrics                     July 2021
+Internet-Draft                 OpenMetrics                September 2021
 
 
    [timestamp]
@@ -2517,4 +2517,4 @@ Authors' Addresses
 
 
 
-Hartmann, et al.         Expires January 2, 2022               [Page 45]
+Hartmann, et al.         Expires March 26, 2022                [Page 45]

--- a/specification/OpenMetrics.txt
+++ b/specification/OpenMetrics.txt
@@ -5,12 +5,12 @@
 Ops WG                                                  R. Hartmann, Ed.
 Internet-Draft                                              Grafana Labs
 Intended status: Standards Track                               B. Kochie
-Expires: March 26, 2022                                           GitLab
+Expires: March 27, 2022                                           GitLab
                                                                B. Brazil
                                                        Robust Perception
                                                           R. Skillington
                                                             Chronosphere
-                                                      September 22, 2021
+                                                      September 23, 2021
 
 
      OpenMetrics, a cloud-native, highly scalable metrics protocol
@@ -39,7 +39,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on March 26, 2022.
+   This Internet-Draft will expire on March 27, 2022.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Hartmann, et al.         Expires March 26, 2022                 [Page 1]
+Hartmann, et al.         Expires March 27, 2022                 [Page 1]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -109,7 +109,7 @@ Table of Contents
 
 
 
-Hartmann, et al.         Expires March 26, 2022                 [Page 2]
+Hartmann, et al.         Expires March 27, 2022                 [Page 2]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -165,7 +165,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                 [Page 3]
+Hartmann, et al.         Expires March 27, 2022                 [Page 3]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -221,7 +221,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                 [Page 4]
+Hartmann, et al.         Expires March 27, 2022                 [Page 4]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -277,7 +277,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                 [Page 5]
+Hartmann, et al.         Expires March 27, 2022                 [Page 5]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -333,7 +333,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                 [Page 6]
+Hartmann, et al.         Expires March 27, 2022                 [Page 6]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -357,7 +357,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
    o  Histogram: '_count', '_sum', '_bucket', '_created'
 
-   o  GaugeHistogram: '_gcount', '_gsum', '_bucket', '_created'
+   o  GaugeHistogram: '_gcount', '_gsum', '_bucket'
 
    o  Info: '_info'
 
@@ -389,7 +389,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                 [Page 7]
+Hartmann, et al.         Expires March 27, 2022                 [Page 7]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -445,7 +445,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                 [Page 8]
+Hartmann, et al.         Expires March 27, 2022                 [Page 8]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -501,7 +501,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                 [Page 9]
+Hartmann, et al.         Expires March 27, 2022                 [Page 9]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -557,7 +557,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 10]
+Hartmann, et al.         Expires March 27, 2022                [Page 10]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -613,7 +613,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 11]
+Hartmann, et al.         Expires March 27, 2022                [Page 11]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -669,7 +669,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 12]
+Hartmann, et al.         Expires March 27, 2022                [Page 12]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -725,7 +725,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 13]
+Hartmann, et al.         Expires March 27, 2022                [Page 13]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -781,7 +781,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 14]
+Hartmann, et al.         Expires March 27, 2022                [Page 14]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -837,7 +837,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 15]
+Hartmann, et al.         Expires March 27, 2022                [Page 15]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -893,7 +893,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 16]
+Hartmann, et al.         Expires March 27, 2022                [Page 16]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -949,7 +949,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 17]
+Hartmann, et al.         Expires March 27, 2022                [Page 17]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1005,7 +1005,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 18]
+Hartmann, et al.         Expires March 27, 2022                [Page 18]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1061,7 +1061,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 19]
+Hartmann, et al.         Expires March 27, 2022                [Page 19]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1117,7 +1117,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 20]
+Hartmann, et al.         Expires March 27, 2022                [Page 20]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1173,7 +1173,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 21]
+Hartmann, et al.         Expires March 27, 2022                [Page 21]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1220,16 +1220,16 @@ Internet-Draft                 OpenMetrics                September 2021
 
    The MetricPoint's Bucket Values Sample MetricNames MUST have the
    suffix "_bucket".  If present, the MetricPoint's Sum Value Sample
-   MetricName MUST have the suffix "_gsum".  If present, the
-   MetricPoint's Created Value Sample MetricName MUST have the suffix
-   "_created".  If and only if a Sum Value is present in a MetricPoint,
-   then the MetricPoint's +Inf Bucket value MUST also appear in a Sample
-   with a MetricName with the suffix "_gcount".
+   MetricName MUST have the suffix "_gsum".  If and only if a Sum Value
+   is present in a MetricPoint, then the MetricPoint's +Inf Bucket value
+   MUST also appear in a Sample with a MetricName with the suffix
+   "_gcount".
 
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 22]
+
+Hartmann, et al.         Expires March 27, 2022                [Page 22]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1241,8 +1241,7 @@ Internet-Draft                 OpenMetrics                September 2021
    no Exemplar with no Exemplars in the buckets: ~~~~ # TYPE foo
    gaugehistogram foo_bucket{le="0.01"} 20.0 foo_bucket{le="0.1"} 25.0
    foo_bucket{le="1"} 34.0 foo_bucket{le="10"} 34.0
-   foo_bucket{le="+Inf"} 42.0 foo_gcount 42.0 foo_gsum 3289.3
-   foo_created 1520430000.123 ~~~~
+   foo_bucket{le="+Inf"} 42.0 foo_gcount 42.0 foo_gsum 3289.3 ~~~~
 
 4.1.5.8.  Unknown
 
@@ -1285,7 +1284,8 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 23]
+
+Hartmann, et al.         Expires March 27, 2022                [Page 23]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1341,7 +1341,7 @@ enum MetricType {
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 24]
+Hartmann, et al.         Expires March 27, 2022                [Page 24]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1397,7 +1397,7 @@ message UnknownValue {
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 25]
+Hartmann, et al.         Expires March 27, 2022                [Page 25]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1453,7 +1453,7 @@ message HistogramValue {
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 26]
+Hartmann, et al.         Expires March 27, 2022                [Page 26]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1509,7 +1509,7 @@ message InfoValue {
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 27]
+Hartmann, et al.         Expires March 27, 2022                [Page 27]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1565,7 +1565,7 @@ message SummaryValue {
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 28]
+Hartmann, et al.         Expires March 27, 2022                [Page 28]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1621,7 +1621,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 29]
+Hartmann, et al.         Expires March 27, 2022                [Page 29]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1677,7 +1677,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 30]
+Hartmann, et al.         Expires March 27, 2022                [Page 30]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1733,7 +1733,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 31]
+Hartmann, et al.         Expires March 27, 2022                [Page 31]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1789,7 +1789,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 32]
+Hartmann, et al.         Expires March 27, 2022                [Page 32]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1845,7 +1845,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 33]
+Hartmann, et al.         Expires March 27, 2022                [Page 33]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1901,7 +1901,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 34]
+Hartmann, et al.         Expires March 27, 2022                [Page 34]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -1957,7 +1957,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 35]
+Hartmann, et al.         Expires March 27, 2022                [Page 35]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -2013,7 +2013,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 36]
+Hartmann, et al.         Expires March 27, 2022                [Page 36]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -2069,7 +2069,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 37]
+Hartmann, et al.         Expires March 27, 2022                [Page 37]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -2125,7 +2125,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 38]
+Hartmann, et al.         Expires March 27, 2022                [Page 38]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -2181,7 +2181,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 39]
+Hartmann, et al.         Expires March 27, 2022                [Page 39]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -2237,7 +2237,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 40]
+Hartmann, et al.         Expires March 27, 2022                [Page 40]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -2293,7 +2293,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 41]
+Hartmann, et al.         Expires March 27, 2022                [Page 41]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -2349,7 +2349,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 42]
+Hartmann, et al.         Expires March 27, 2022                [Page 42]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -2405,7 +2405,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 43]
+Hartmann, et al.         Expires March 27, 2022                [Page 43]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -2461,7 +2461,7 @@ Internet-Draft                 OpenMetrics                September 2021
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 44]
+Hartmann, et al.         Expires March 27, 2022                [Page 44]
 
 Internet-Draft                 OpenMetrics                September 2021
 
@@ -2517,4 +2517,4 @@ Authors' Addresses
 
 
 
-Hartmann, et al.         Expires March 26, 2022                [Page 45]
+Hartmann, et al.         Expires March 27, 2022                [Page 45]


### PR DESCRIPTION
Further down the  document, `_created` is mentioned as a possible suffix for GaugeHistograms

https://github.com/OpenObservability/OpenMetrics/blob/45ae6699a4ba83368f0b481f05e798ba3c398eec/specification/OpenMetrics.md#gaugehistogram-1

https://github.com/OpenObservability/OpenMetrics/blame/45ae6699a4ba83368f0b481f05e798ba3c398eec/specification/OpenMetrics.md#L793