### PR TITLE
Remove not true statement about OpenMetrics being the official standard in Prometheus

### DIFF
--- a/website/config.yaml
+++ b/website/config.yaml
@@ -5,7 +5,7 @@ disableKinds: [taxonomy, taxonomyTerm]
 
 params:
   description: |
-    OpenMetrics is the official standard for metrics in the [Prometheus](https://prometheus.io/) ecosystem. With its support for examplars, it ties metrics and traces as closely and efficiently as never seen before. The [specification](https://github.com/OpenObservability/OpenMetrics/blob/master/specification/OpenMetrics.md) covers semantics, data model, and wire format for cloud-native metrics at scale, with support for both text representation and Protocol Buffers.
+    OpenMetrics is partially supported by [Prometheus](https://prometheus.io/) ecosystem. With its support for examplars, it ties metrics and traces as closely and efficiently as never seen before. The [specification](https://github.com/OpenObservability/OpenMetrics/blob/master/specification/OpenMetrics.md) covers semantics, data model, and wire format for cloud-native metrics at scale, with support for both text representation and Protocol Buffers.
   subdescription: |
     You can track the project's progress on the [OpenMetrics mailing list](https://groups.google.com/forum/m/#!forum/openmetrics).
   favicon: /images/logo/logo.png


### PR DESCRIPTION
* Not all Prometheus clients support exporting OpenMetrics, and not all Prometheus clients do this by default.
* Prometheus Text 0.4 is not compatible with OpenMetrics for things like Meta for Counters, etc.

Because of these things I think OpenMetrics should remove this claim, until Prometheus properly adopt OpenMetrics.

Signed-off-by: Bogdan Drutu <bogdandrutu@gmail.com>