### PR TITLE
Clarify compatibility and content negotiation

### DIFF
--- a/specification/OpenMetrics.md
+++ b/specification/OpenMetrics.md
@@ -34,6 +34,7 @@ normative:
   RFC2119:
   RFC5234:
   RFC8174:
+  RFC9110:
 
 informative:
   normalization:
@@ -307,11 +308,35 @@ The text format compresses well, and protobuf is already binary and efficiently 
 
 Partial or invalid expositions MUST be considered erroneous in their entirety.
 
+## Versioning and compatibility
+
+### ABNF specification
+
+Versioning follows a semantic versioning model on the specification level. Breaking semantic changes (for example removal from ABNF) MUST result in major version bump, however additions MUST be in a minor version bump. Multiple changes may be bundled in the same version update and the version bump will be the biggest version bump in those changes.
+
+### Ingestor
+
+Ingestors MUST implement at least version 1.0.0 of the standard.
+Ingestors MUST implement protocol negotiation to be able to support higher than 1.0.0 version.
+If exposer doesn't support content negotiation, version 1.0.0 SHOULD be assumed.
+
+An ingestor that supports version "m.y" of the standard MUST support versions "m.x" where "x" and "y" are natural numbers, such that "x < y".
+
+Ingestors MAY refuse to ingest the exposed metrics if content negotiation yields an empty list of versions.
+
+### Exposer
+
+Exposers MUST implement at least version 1.0.0 of the standard.
+Exposers MUST implement protocol negotiation to be able to support higher than 1.0.0 version.
+Exposers SHOULD negotiate the highest common version with the exposer.
+
 ## Protocol Negotiation
 
 All ingestor implementations MUST be able to ingest data secured with TLS 1.2 or later. All exposers SHOULD be able to emit data secured with TLS 1.2 or later. ingestor implementations SHOULD be able to ingest data from HTTP without TLS. All implementations SHOULD use TLS to transmit data.
 
-Negotiation of what version of the OpenMetrics format to use is out-of-band. For example for pull-based exposition over HTTP standard HTTP content type negotiation is used, and MUST default to the oldest version of the standard (i.e. 1.0.0) if no newer version is requested.
+Negotiation of what version of the OpenMetrics format to use is out-of-band. For example for pull-based exposition over HTTP the standard HTTP content type negotiation MUST be used. The ingestor MUST send the "Accept" header according to RFC 9110 and indicate the versions it supports, for example
+
+application/openmetrics-text;version=1.0.0;q=0.7,application/openmetrics-text;version=1.1.0;q=0.8
 
 Push-based negotiation is inherently more complex, as the exposer typically initiates the connection. Producers MUST use the oldest version of the standard (i.e. 1.0.0) unless requested otherwise by the ingestor.
 


### PR DESCRIPTION
Following the dev summit on 13th September in Berlin.

https://docs.google.com/document/d/1uurQCi5iVufhYHGlBZ8mJMK_freDFKPG0iYBQqJ9fvA/edit#bookmark=id.kj599un8yoj7

From the dev summit document:
```
CONSENSUS: We intend to add native histograms as a part of OpenMetrics 1.1. A major version bump is not required.
CONSENSUS: We agree that the understanding of backwards compatibility is that a A.y parser can also parse an A.x format. But the A.x parser doesn’t need to parse the A.y format. Where y > x, A, x, y being integers
CONSENSUS: OpenMetrics doesn’t need a major version bump if the changes are backwards compatible.
```

Notes:
- this is my understanding
- I'm suggesting a more comprehensive update than agreed in the dev summit
- I think the document should actually state its own version (1.0.0)  , but I'll leave that to a different PR

